### PR TITLE
create applyOptimistic store enhancer

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-register": "^6.9.0",
     "coveralls": "^2.11.9",
     "nyc": "^6.6.1",
+    "redux": "^3.5.2",
     "rimraf": "^2.5.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,19 @@ export const ensureState = state => {
   return state;
 };
 
+export const applyOptimistic = rawConfig => createStore => (reducer, ...args) => {
+  const store = createStore(optimistic(reducer, rawConfig), ...args); 
+  return {
+    ...store,
+    getState() {
+      return ensureState(store.getState());
+    },
+    replaceReducer(nextReducer) {
+      return store.replaceReducer(optimistic(nextReducer, rawConfig));
+    }
+  };
+};
+
 const applyCommit = (state, commitId, reducer) => {
   const history = state.get('history');
   // If the action to commit is the first in the queue (most common scenario)


### PR DESCRIPTION
Having to wrap `getState` calls in `ensureState` everywhere irks me for several reasons:
* You may have to make changes to numerous places to add it to an existing app
* It gets kind of awkward if there are other reducer enhancers doing the same thing to unwrap all of that state 

So I created an optional `applyOptimistic` store enhancer that applies the `optimistic` reducer enhancer and calls `ensureState` internally, meaning the store could be used without doing any `ensureState` in `mapStateToProps` in userland.

I'm not 100% satisfied with this though given that *middleware* still has to use `ensureState` (Redux docs explain that `applyMiddleware` should come before other store enhancers because they can dispatch actions asynchronously that need to be seen by the other enhancers.

What do you think?  Do you think it would be better to use middleware than a reducer enhancer?