### PR TITLE
Don't force further transpilation to use internal .babelrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ src/
 __tests__/
 node_modules
 .idea
+.babelrc


### PR DESCRIPTION
For any consumers that want to transpile this package with babel further, 
they shouldn't be required to use the same presets defined in the local
.babelrc file. Those have already been applied for the npm package.