### PR TITLE
Use a value set on the state itself rather than an isReady flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-register": "^6.9.0",
     "coveralls": "^2.11.9",
     "nyc": "^6.6.1",
+    "redux": "^3.6.0",
     "rimraf": "^2.5.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -89,19 +89,25 @@ const applyRevert = (state, revertId, reducer) => {
   });
 };
 
+const isInitialized  = (state, readyValue) => (
+  state !== undefined &&
+  typeof state.get === 'function' &&
+  state.get('isReady') === readyValue
+);
+
 export const optimistic = (reducer, rawConfig = {}) => {
   const config = Object.assign({
     maxHistory: 100
   }, rawConfig);
-  let isReady = false;
+  const readyValue = Math.random()
 
   return (state, action) => {
-    if (!isReady || state === undefined) {
-      isReady = true;
+    if (!isInitialized(state, readyValue)) {
       state = Map({
         history: List(),
         current: reducer(ensureState(state), {}),
-        beforeState: undefined
+        beforeState: undefined,
+        isReady: readyValue
       });
     }
     const historySize = state.get('history').size;


### PR DESCRIPTION
When redux initializes it passes a couple of actions to each reducer.
This initialization was setting the "isReady" flag. If we have an
initial state coming from outside of the reducer, however, then on the
actual @@INIT pass the isReady flag would be true and the state be
defined even though it isn't actually initialized.

By using a flag on the state itself we can ensure that the state is
properly initialized.

Fixes #16