### PR TITLE
Add a helper function to preload state with an initial state that works with optismitic 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-register": "^6.9.0",
     "coveralls": "^2.11.9",
     "nyc": "^6.6.1",
+    "redux": "^3.6.0",
     "rimraf": "^2.5.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,12 @@ export const ensureState = state => {
   return state;
 };
 
+export const preloadState = state => Map({
+  beforeState: undefined,
+  history: List(),
+  current: state
+});
+
 const applyCommit = (state, commitId, reducer) => {
   const history = state.get('history');
   // If the action to commit is the first in the queue (most common scenario)
@@ -97,12 +103,8 @@ export const optimistic = (reducer, rawConfig = {}) => {
 
   return (state, action) => {
     if (!isReady || state === undefined) {
-      isReady = true;
-      state = Map({
-        history: List(),
-        current: reducer(ensureState(state), {}),
-        beforeState: undefined
-      });
+      isReady = true
+      state = preloadState(reducer(ensureState(state), {}));
     }
     const historySize = state.get('history').size;
     const {type, id} = (action.meta && action.meta.optimistic) || {};


### PR DESCRIPTION
When redux initializes it passes a couple of actions to each reducer.
This initialization was sets the "isReady" flag. If we have an
initial state coming from outside of the reducer, however, then on the
actual @@INIT pass the isReady flag would be true and the state be
defined even though it isn't actually initialized.

In this instance, use the preloadState function to pass in the initial
value so it's already set up for optimistic.

Fixes #16