### PR TITLE
Support intiialState in deep optimistic reducers without preloadState

### DIFF
--- a/__tests__/index-tests.js
+++ b/__tests__/index-tests.js
@@ -375,22 +375,22 @@ test('real world', t => {
   t.deepEqual(actual.toJS(), expected.toJS());
 });
 
-test('with redux and preloadState', t => {
+test('with redux and initialState with preloadState', t => {
   const enhancedReducer = combineReducers({
     counter: optimistic(counterReducer)
   });
   try {
     const store = createStore(enhancedReducer, {
-      counter: preloadState(0)
+      counter: preloadState(1)
     });
     store.dispatch({type: 'INC'});
-    t.is(ensureState(store.getState().counter), 1);
+    t.is(ensureState(store.getState().counter), 2);
   } catch (error) {
     t.fail(error.message)
   }
 });
 
-test('with redux and intiialState without preloadState', t => {
+test('with redux and initialState without preloadState', t => {
   const enhancedReducer = combineReducers({
     counter: optimistic(counterReducer)
   });

--- a/__tests__/index-tests.js
+++ b/__tests__/index-tests.js
@@ -375,7 +375,7 @@ test('real world', t => {
   t.deepEqual(actual.toJS(), expected.toJS());
 });
 
-test('with redux', t => {
+test('with redux and preloadState', t => {
   const enhancedReducer = combineReducers({
     counter: optimistic(counterReducer)
   });
@@ -385,6 +385,21 @@ test('with redux', t => {
     });
     store.dispatch({type: 'INC'});
     t.is(ensureState(store.getState().counter), 1);
+  } catch (error) {
+    t.fail(error.message)
+  }
+});
+
+test('with redux and intiialState without preloadState', t => {
+  const enhancedReducer = combineReducers({
+    counter: optimistic(counterReducer)
+  });
+  try {
+    const store = createStore(enhancedReducer, {
+      counter: 1
+    });
+    store.dispatch({type: 'INC'});
+    t.is(ensureState(store.getState().counter), 2);
   } catch (error) {
     t.fail(error.message)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ export const optimistic = (reducer, rawConfig = {}) => {
   let isReady = false;
 
   return (state, action) => {
-    if (!isReady || state === undefined) {
+    if (!isReady || state === undefined || action.type === '@@redux/INIT') {
       isReady = true
       state = preloadState(reducer(ensureState(state), {}));
     }

--- a/src/index.js
+++ b/src/index.js
@@ -99,11 +99,9 @@ export const optimistic = (reducer, rawConfig = {}) => {
   const config = Object.assign({
     maxHistory: 100
   }, rawConfig);
-  let isReady = false;
 
   return (state, action) => {
-    if (!isReady || state === undefined || action.type === '@@redux/INIT') {
-      isReady = true
+    if (state === undefined || action.type === '@@redux/INIT') {
       state = preloadState(reducer(ensureState(state), {}));
     }
     const historySize = state.get('history').size;

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export const ensureState = state => {
   return state;
 };
 
-export const preloadState = state => Map({
+const createState = state => Map({
   beforeState: undefined,
   history: List(),
   current: state
@@ -102,7 +102,7 @@ export const optimistic = (reducer, rawConfig = {}) => {
 
   return (state, action) => {
     if (state === undefined || action.type === '@@redux/INIT') {
-      state = preloadState(reducer(ensureState(state), {}));
+      state = createState(reducer(ensureState(state), {}));
     }
     const historySize = state.get('history').size;
     const {type, id} = (action.meta && action.meta.optimistic) || {};


### PR DESCRIPTION
Currently the `preloadState` function is used to provide intiial state in
a form that redux-optimist-ui expects, however by instead also initialising
the state on the `@@redux/INIT` action we can setup the state correctly
_without_ explcitly calling `preloadState` in the state we pass to
`createStore`.

Fixes #22