### PR TITLE
Replace ImmutableJS with native javascript methods

### DIFF
--- a/__tests__/array-utils-tests.js
+++ b/__tests__/array-utils-tests.js
@@ -1,0 +1,26 @@
+import test from 'ava';
+import 'babel-register';
+
+import { findIndex } from '../src/array-utils';
+
+const noop = () => {};
+
+test('findIndex returns -1 with empty array', t => {
+    const actual = findIndex([], noop);
+    t.is(actual, -1);
+});
+
+test('findIndex returns -1 with no-op predicate', t => {
+    const actual = findIndex([1, 2, 3, 4], noop);
+    t.is(actual, -1);
+});
+
+test('findIndex returns first match with mutliple match predicate', t => {
+    const actual = findIndex([1, 2, 3, 4], e => e % 2 === 0)
+    t.is(actual, 1);
+});
+
+test('findIndex returns -1 with no match predicate', t => {
+    const actual = findIndex([1, 2, 3, 4], e => e % 5 === 0)
+    t.is(actual, -1);
+});

--- a/__tests__/array-utils-tests.js
+++ b/__tests__/array-utils-tests.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import 'babel-register';
 
-import { find, findIndex } from '../src/array-utils';
+import { findIndex } from '../src/array-utils';
 
 const noop = () => {};
 
@@ -23,14 +23,4 @@ test('findIndex returns first match with mutliple match predicate', t => {
 test('findIndex returns -1 with no match predicate', t => {
     const actual = findIndex([1, 2, 3, 4], e => e % 5 === 0)
     t.is(actual, -1);
-});
-
-test('find returns first element when multiple matches exists', t => {
-    const actual = find([1, 2, 3, 4], e => e % 2 === 0);
-    t.is(actual, 2);
-});
-
-test('find returns undefined when no match exists', t => {
-    const actual = find([1, 2, 3, 4], e => e % 5 === 0);
-    t.is(actual, undefined);
 });

--- a/__tests__/array-utils-tests.js
+++ b/__tests__/array-utils-tests.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import 'babel-register';
 
-import { findIndex } from '../src/array-utils';
+import { find, findIndex } from '../src/array-utils';
 
 const noop = () => {};
 
@@ -23,4 +23,14 @@ test('findIndex returns first match with mutliple match predicate', t => {
 test('findIndex returns -1 with no match predicate', t => {
     const actual = findIndex([1, 2, 3, 4], e => e % 5 === 0)
     t.is(actual, -1);
+});
+
+test('find returns first element when multiple matches exists', t => {
+    const actual = find([1, 2, 3, 4], e => e % 2 === 0);
+    t.is(actual, 2);
+});
+
+test('find returns undefined when no match exists', t => {
+    const actual = find([1, 2, 3, 4], e => e % 5 === 0);
+    t.is(actual, undefined);
 });

--- a/__tests__/index-tests.js
+++ b/__tests__/index-tests.js
@@ -198,6 +198,26 @@ test('begin 2, add non-opt action, commit the first', t => {
   t.deepEqual(actual, expected);
 });
 
+test('begin 2, commit the second', t => {
+  const enhancedReducer = optimistic(rootReducer);
+  const begin0 = makeAction('INC', BEGIN, 0);
+  const begin1 = makeAction('DEC', BEGIN, 1);
+  const commit0 = makeAction('--', COMMIT, 1);
+
+  // optimistic DEC will be converted to a non-opt action in history
+  const converted0 = {type: 'DEC', meta: { optimistic: null } };
+
+  const state1 = enhancedReducer(undefined, begin0);
+  const state2 = enhancedReducer(state1, begin1);
+  const actual = enhancedReducer(state2, commit0);
+  const expected = {
+    beforeState: actual.current,
+    history: [begin0, converted0, commit0],
+    current: {counter: 0}
+  };
+  t.deepEqual(actual, expected);
+});
+
 /*REVERT*/
 test('immediately revert a transaction', t => {
   const enhancedReducer = optimistic(rootReducer);

--- a/__tests__/index-tests.js
+++ b/__tests__/index-tests.js
@@ -9,6 +9,10 @@ import {
 } from '../src/index';
 import {createStore, combineReducers} from 'redux';
 
+// while there isn't an Immutable dependency in the library anymore we want to verify backwards
+// compat with immutable wrapped reducers
+import { List, Map, is } from 'immutable';
+
 const INIT_ACTION = { type: '@@redux/INIT' };
 
 const counterReducer = (state = 0, action) => {
@@ -22,6 +26,8 @@ const counterReducer = (state = 0, action) => {
   }
 };
 const rootReducer = (state = {}, action) => ({counter: counterReducer(state.counter, action)});
+const rootReducerImmutable = (state = Map(), action) => Map({counter: counterReducer(state.get('counter'), action)});
+
 const enhancedRootReducerNested = combineReducers({
   counter1: combineReducers({ counter: optimistic(counterReducer) }),
   counter2: combineReducers({ counter: optimistic(counterReducer) })
@@ -70,6 +76,17 @@ test('wraps a reducer with existing state', t => {
     beforeState: undefined,
     history: [],
     current: {counter: 5}
+  };
+  t.deepEqual(actual, expected);
+});
+
+test('wraps an immutable reducer', t => {
+  const enhancedReducer = optimistic(rootReducerImmutable);
+  const actual = enhancedReducer(undefined, {});
+  const expected = {
+    beforeState: undefined,
+    history: [],
+    current: Map({counter: 0})
   };
   t.deepEqual(actual, expected);
 });

--- a/__tests__/index-tests.js
+++ b/__tests__/index-tests.js
@@ -7,7 +7,6 @@ import {
   REVERT,
   ensureState
 } from '../src/index';
-import {Map, List, is} from 'immutable';
 import {createStore, combineReducers} from 'redux';
 
 const INIT_ACTION = { type: '@@redux/INIT' };
@@ -23,7 +22,6 @@ const counterReducer = (state = 0, action) => {
   }
 };
 const rootReducer = (state = {}, action) => ({counter: counterReducer(state.counter, action)});
-const rootReducerImmutable = (state = Map(), action) => Map({counter: counterReducer(state.get('counter'), action)});
 const enhancedRootReducerNested = combineReducers({
   counter1: combineReducers({ counter: optimistic(counterReducer) }),
   counter2: combineReducers({ counter: optimistic(counterReducer) })
@@ -45,47 +43,35 @@ test('test rootReducerImmutable works OK', t => {
 
 test('test enhancedRootReducerNested works OK', t => {
   const actual = enhancedRootReducerNested(undefined, INIT_ACTION);
-  const expected = Map({
+  const expected = {
       beforeState: undefined,
-      history: List(),
+      history: [],
       current: 0
-  })
-  t.deepEqual(actual.counter1.counter.toJS(), expected.toJS())
-  t.deepEqual(actual.counter2.counter.toJS(), expected.toJS())
+  };
+  t.deepEqual(actual.counter2.counter, expected)
 })
 
 /*BASIC*/
 test('wraps a reducer', t => {
   const enhancedReducer = optimistic(rootReducer);
   const actual = enhancedReducer(undefined, INIT_ACTION);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: 0}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('wraps a reducer with existing state', t => {
   const enhancedReducer = optimistic(rootReducer);
   const actual = enhancedReducer({counter: 5}, INIT_ACTION);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: 5}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
-});
-
-test('wraps an immutable reducer', t => {
-  const enhancedReducer = optimistic(rootReducerImmutable);
-  const actual = enhancedReducer(undefined, INIT_ACTION);
-  const expected = Map({
-    beforeState: undefined,
-    history: List(),
-    current: Map({counter: 0})
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 /*BEGIN*/
@@ -93,12 +79,12 @@ test('begin a transaction', t => {
   const enhancedReducer = optimistic(rootReducer);
   const action = makeAction('INC', BEGIN, 0);
   const actual = enhancedReducer(undefined, action);
-  const expected = Map({
+  const expected = {
     beforeState: {counter: 0},
-    history: List.of(action),
+    history: [action],
     current: {counter: 1}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin a second transaction', t => {
@@ -107,12 +93,12 @@ test('begin a second transaction', t => {
   const begin1 = makeAction('INC', BEGIN, 1);
   const state1 = enhancedReducer(undefined, begin0);
   const actual = enhancedReducer(state1, begin1);
-  const expected = Map({
+  const expected = {
     beforeState: {counter: 0},
-    history: List.of(begin0, begin1),
+    history: [begin0, begin1],
     current: {counter: 2}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin a transaction, add a non-opt', t => {
@@ -121,12 +107,12 @@ test('begin a transaction, add a non-opt', t => {
   const nonOpt0 = {type: 'DEC'};
   const state1 = enhancedReducer(undefined, begin0);
   const actual = enhancedReducer(state1, nonOpt0);
-  const expected = Map({
+  const expected = {
     beforeState: {counter: 0},
-    history: List.of(begin0, nonOpt0),
+    history: [begin0, nonOpt0],
     current: {counter: 0}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 2, add non-opt', t => {
@@ -137,12 +123,12 @@ test('begin 2, add non-opt', t => {
   const state1 = enhancedReducer(undefined, begin0);
   const state2 = enhancedReducer(state1, begin1);
   const actual = enhancedReducer(state2, nonOpt0);
-  const expected = Map({
+  const expected = {
     beforeState: {counter: 0},
-    history: List.of(begin0, begin1, nonOpt0),
+    history: [begin0, begin1, nonOpt0],
     current: {counter: 1}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 
@@ -153,12 +139,12 @@ test('immediately commit a transaction', t => {
   const state1 = enhancedReducer(undefined, begin0);
   const commit0 = makeAction('--', COMMIT, 0);
   const actual = enhancedReducer(state1, commit0);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: 1}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 2, commit the first', t => {
@@ -169,12 +155,12 @@ test('begin 2, commit the first', t => {
   const state1 = enhancedReducer(undefined, begin0);
   const state2 = enhancedReducer(state1, begin1);
   const actual = enhancedReducer(state2, commit0);
-  const expected = Map({
-    beforeState: state1.get('current'),
-    history: List.of(begin1, commit0),
+  const expected = {
+    beforeState: state1.current,
+    history: [begin1, commit0],
     current: {counter: 2}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 2, add non-opt action, commit the first', t => {
@@ -187,12 +173,12 @@ test('begin 2, add non-opt action, commit the first', t => {
   const state2 = enhancedReducer(state1, begin1);
   const state3 = enhancedReducer(state2, nonOpt0);
   const actual = enhancedReducer(state3, commit0);
-  const expected = Map({
-    beforeState: state1.get('current'),
-    history: List.of(begin1, nonOpt0, commit0),
+  const expected = {
+    beforeState: state1.current,
+    history: [begin1, nonOpt0, commit0],
     current: {counter: 1}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 /*REVERT*/
@@ -202,12 +188,12 @@ test('immediately revert a transaction', t => {
   const state1 = enhancedReducer(undefined, begin0);
   const revertAction = makeAction('--', REVERT, 0);
   const actual = enhancedReducer(state1, revertAction);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: 0}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 2, revert the second', t => {
@@ -218,12 +204,12 @@ test('begin 2, revert the second', t => {
   const state1 = enhancedReducer(undefined, begin0);
   const state2 = enhancedReducer(state1, begin1);
   const actual = enhancedReducer(state2, revert0);
-  const expected = Map({
+  const expected = {
     beforeState: {counter: 0},
-    history: List.of(begin0, revert0),
+    history: [begin0, revert0],
     current: {counter: 1}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 2, revert the first', t => {
@@ -234,12 +220,12 @@ test('begin 2, revert the first', t => {
   const state1 = enhancedReducer(undefined, begin0);
   const state2 = enhancedReducer(state1, begin1);
   const actual = enhancedReducer(state2, revert0);
-  const expected = Map({
+  const expected = {
     beforeState: {counter: 0},
-    history: List.of(begin1, revert0),
+    history: [begin1, revert0],
     current: {counter: 1}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 2, revert the first, then the second', t => {
@@ -252,12 +238,12 @@ test('begin 2, revert the first, then the second', t => {
   const state2 = enhancedReducer(state1, begin1);
   const state3 = enhancedReducer(state2, revert0);
   const actual = enhancedReducer(state3, secondRevert);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: 0}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 1, add non-opt, revert it', t => {
@@ -268,12 +254,12 @@ test('begin 1, add non-opt, revert it', t => {
   const state1 = enhancedReducer(undefined, begin0);
   const state2 = enhancedReducer(state1, nonOpt0);
   const actual = enhancedReducer(state2, revert0);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: -1}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 1 with nested combineReducers, revert', t => {
@@ -281,13 +267,13 @@ test('begin 1 with nested combineReducers, revert', t => {
   const revert = makeAction('--', REVERT, 0);
   const state = enhancedRootReducerNested(undefined, begin);
   const actual = enhancedRootReducerNested(state, revert);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: 0
-  });
-  t.deepEqual(actual.counter1.counter.toJS(), expected.toJS());
-  t.deepEqual(actual.counter2.counter.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual.counter1.counter, expected);
+  t.deepEqual(actual.counter2.counter, expected);
 });
 
 test('begin 2, add non-opt, revert first', t => {
@@ -300,12 +286,12 @@ test('begin 2, add non-opt, revert first', t => {
   const state2 = enhancedReducer(state1, begin1);
   const state3 = enhancedReducer(state2, nonOpt0);
   const actual = enhancedReducer(state3, revert0);
-  const expected = Map({
+  const expected = {
     beforeState: {counter: 0},
-    history: List.of(begin1,nonOpt0, revert0),
+    history: [begin1,nonOpt0, revert0],
     current: {counter: 0}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('begin 2, add non-opt, revert the first, commit the second', t => {
@@ -320,12 +306,12 @@ test('begin 2, add non-opt, revert the first, commit the second', t => {
   const state3 = enhancedReducer(state2, nonOpt0);
   const fourthState = enhancedReducer(state3, revert0);
   const actual = enhancedReducer(fourthState, commit0);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: 0}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('revert and commit have an extra DEC', t => {
@@ -340,12 +326,12 @@ test('revert and commit have an extra DEC', t => {
   const state3 = enhancedReducer(state2, nonOpt0);
   const fourthState = enhancedReducer(state3, revert0);
   const actual = enhancedReducer(fourthState, commit0);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: -2}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('real world', t => {
@@ -368,12 +354,12 @@ test('real world', t => {
   const state7 = enhancedReducer(state6, commit0);
   const state8 = enhancedReducer(state7, nonOpt2);
   const actual = enhancedReducer(state8, revert2);
-  const expected = Map({
+  const expected = {
     beforeState: undefined,
-    history: List(),
+    history: [],
     current: {counter: -2}
-  });
-  t.deepEqual(actual.toJS(), expected.toJS());
+  };
+  t.deepEqual(actual, expected);
 });
 
 test('with redux and initialState without preloadState', t => {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
     "coveralls": "^2.11.9",
+    "immutable": "^3.8.1",
     "nyc": "^6.6.1",
     "redux": "^3.6.0",
     "rimraf": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
     "url": "https://github.com/mattkrick/redux-optimistic-ui/issues"
   },
   "homepage": "https://github.com/mattkrick/redux-optimistic-ui#readme",
-  "dependencies": {
-    "immutable": "^3.8.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "ava": "^0.18.1",
     "babel-cli": "^6.10.1",

--- a/src/array-utils.js
+++ b/src/array-utils.js
@@ -7,3 +7,8 @@ export function findIndex(arr, predicate) {
   }
   return -1;
 }
+
+export function find(arr, predicate) {
+    const index = findIndex(arr, predicate);
+    return index === -1 ? undefined : arr[index];
+}

--- a/src/array-utils.js
+++ b/src/array-utils.js
@@ -1,0 +1,9 @@
+export function findIndex(arr, predicate) {
+  const l = arr.length;
+  for (let i = 0; i < l; i++) {
+    if (predicate(arr[i])) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/src/array-utils.js
+++ b/src/array-utils.js
@@ -7,8 +7,3 @@ export function findIndex(arr, predicate) {
   }
   return -1;
 }
-
-export function find(arr, predicate) {
-    const index = findIndex(arr, predicate);
-    return index === -1 ? undefined : arr[index];
-}

--- a/src/index.js
+++ b/src/index.js
@@ -47,18 +47,21 @@ const applyCommit = (state, commitId, reducer) => {
     };
   } else {
     // If the committed action isn't the first in the queue, find out where it is
-    const actionToCommit = find(history, action => action.meta && action.meta.optimistic && action.meta.optimistic.id === commitId);
-    if (!actionToCommit) {
+    const actionToCommitIndex = findIndex(history, action => action.meta && action.meta.optimistic && action.meta.optimistic.id === commitId);
+    if (!actionToCommitIndex) {
       console.error(`@@optimist: Failed commit. Transaction #${commitId} does not exist!`);
     }
+    const actionToCommit = history[actionToCommitIndex];
     // Make it a regular non-optimistic action
-    const newAction = Object.assign({}, actionToCommit[1], {
-      meta: Object.assign({}, actionToCommit[1].meta,
+    const newAction = Object.assign({}, actionToCommit, {
+      meta: Object.assign({}, actionToCommit.meta,
         {optimistic: null})
     });
+    const newHistory = state.history.slice();
+    newHistory.splice(actionToCommitIndex, 1, newAction);
     return {
       ...state,
-      history: [newAction].concat(state.history.slice(1))
+      history: newHistory,
     };
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { find, findIndex } from './array-utils';
+import { findIndex } from './array-utils';
 
 export const BEGIN = '@@optimist/BEGIN';
 export const COMMIT = '@@optimist/COMMIT';

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,6 @@ const createState = state => ({
   current: state
 });
 
-const shift = arr => {
-    const newArr = arr.slice();
-    newArr.shift();
-    return newArr;
-}
-
 const findIndex = (arr, fn) => {
   const l = arr.length;
   for (let i = 0; i < l; i++) {
@@ -37,7 +31,7 @@ const applyCommit = (state, commitId, reducer) => {
   const { history } = state;
   // If the action to commit is the first in the queue (most common scenario)
   if (history[0].meta.optimistic.id === commitId) {
-    const historyWithoutCommit = shift(history);
+    const historyWithoutCommit = history.slice(1);
     const nextOptimisticIndex = findIndex(historyWithoutCommit, action => action.meta && action.meta.optimistic && !action.meta.optimistic.isNotOptimistic && action.meta.optimistic.id);
     // If this is the only optimistic item in the queue, we're done!
     if (nextOptimisticIndex === -1) {
@@ -82,7 +76,7 @@ const applyRevert = (state, revertId, reducer) => {
   let newHistory;
   // If the action to revert is the first in the queue (most common scenario)
   if (history[0].meta.optimistic.id === revertId) {
-    const historyWithoutRevert = shift(history);
+    const historyWithoutRevert = history.slice(1);
     const nextOptimisticIndex = findIndex(historyWithoutRevert, action => action.meta && action.meta.optimistic && !action.meta.optimistic.isNotOptimistic && action.meta.optimistic.id);
     // If this is the only optimistic action in the queue, we're done!
     if (nextOptimisticIndex === -1) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { findIndex } from './array-utils';
+import { find, findIndex } from './array-utils';
 
 export const BEGIN = '@@optimist/BEGIN';
 export const COMMIT = '@@optimist/COMMIT';
@@ -47,7 +47,7 @@ const applyCommit = (state, commitId, reducer) => {
     };
   } else {
     // If the committed action isn't the first in the queue, find out where it is
-    const actionToCommit = history.find(action => action.meta && action.meta.optimistic && action.meta.optimistic.id === commitId);
+    const actionToCommit = find(history, action => action.meta && action.meta.optimistic && action.meta.optimistic.id === commitId);
     if (!actionToCommit) {
       console.error(`@@optimist: Failed commit. Transaction #${commitId} does not exist!`);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,8 @@ export const COMMIT = '@@optimist/COMMIT';
 export const REVERT = '@@optimist/REVERT';
 
 export const ensureState = state => {
-  if (state instanceof Object) {
-    if (Array.isArray(state.history)) {
-      return state.current;
-    }
+  if (state && Array.isArray(state.history)) {
+    return state.current;
   }
   return state;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { findIndex } from './array-utils';
+
 export const BEGIN = '@@optimist/BEGIN';
 export const COMMIT = '@@optimist/COMMIT';
 export const REVERT = '@@optimist/REVERT';
@@ -16,16 +18,6 @@ const createState = state => ({
   history: [],
   current: state
 });
-
-const findIndex = (arr, fn) => {
-  const l = arr.length;
-  for (let i = 0; i < l; i++) {
-    if (fn(arr[i])) {
-      return i;
-    }
-  }
-  return -1;
-}
 
 const applyCommit = (state, commitId, reducer) => {
   const { history } = state;


### PR DESCRIPTION
This fixes #21 - replacing the use of ImmutableJS with native JavaScript, while maintaining immutability.

Note that Immutable is still a devDep, because I kept the test that had an Immutable reducer to ensure backwards compatibility in that regard.