### PR TITLE
Improve Babel coverage instrumentation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
   "presets": ["es2015", "stage-0"],
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 node_modules
 .idea
 .nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "xo src/index.js --esnext --space --fix",
     "build": "babel --presets es2015,stage-0 -d lib/ src/",
     "prepublish": "npm run clean && npm run build",
-    "test": "nyc ava __tests__/**/*.js",
+    "test": "cross-env NODE_ENV=test nyc ava __tests__/**/*.js",
     "watch": "babel -w --presets es2015,stage-0 -d lib/ src/"
   },
   "repository": {
@@ -33,12 +33,25 @@
   "devDependencies": {
     "ava": "^0.18.1",
     "babel-cli": "^6.10.1",
+    "babel-plugin-istanbul": "^4.1.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.9.0",
     "coveralls": "^2.11.9",
+    "cross-env": "^5.0.1",
     "nyc": "^6.6.1",
     "redux": "^3.6.0",
     "rimraf": "^2.5.3"
+  },
+  "nyc": {
+    "require": [
+      "babel-register"
+    ],
+    "sourceMap": false,
+    "instrument": false,
+    "reporter": [
+      "lcov",
+      "text"
+    ]
   }
 }


### PR DESCRIPTION
Use the babel-preset-istanbul to provide better coverage instrumentation
of ES6 sources. Add `nyc` config to `pacakge.json` as per instructions at
https://github.com/istanbuljs/nyc#use-with-babel-plugin-istanbul-for-babel-support, 
and change the command for running tests to use `NODE_ENV=test` via `cross-env`.

This also adds the production of a HTML coverage report into the `coverage` directory,
so this directory has been added to `.gitignore`.

Note that the reported coverage will be lower than previously, but more accurate for the sources. It's mostly around the `console.errors` for invalid transaction ids - the attempt to cover which led me to discover the bug in #32.