### PR TITLE
change method for detemrining whether state is already wrapped in reducer

### DIFF
--- a/__tests__/index-tests.js
+++ b/__tests__/index-tests.js
@@ -8,6 +8,7 @@ import {
   ensureState
 } from '../src/index';
 import {createStore, combineReducers} from 'redux';
+import instrument from 'redux-devtools-instrument';
 
 // while there isn't an Immutable dependency in the library anymore we want to verify backwards
 // compat with immutable wrapped reducers
@@ -429,6 +430,21 @@ test('with redux and initialState without preloadState', t => {
     const store = createStore(enhancedReducer, {
       counter: 1
     });
+    store.dispatch({type: 'INC'});
+    t.is(ensureState(store.getState().counter), 2);
+  } catch (error) {
+    t.fail(error.message)
+  }
+});
+
+test('works with preloadState and redux-devtools-instrumentation', t => {
+  const enhancedReducer = combineReducers({
+    counter: optimistic(counterReducer)
+  });
+  try {
+    const store = createStore(enhancedReducer, {
+      counter: 1
+    }, instrument((state, action) => state));
     store.dispatch({type: 'INC'});
     t.is(ensureState(store.getState().counter), 2);
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "immutable": "^3.8.1",
     "nyc": "^6.6.1",
     "redux": "^3.6.0",
+    "redux-devtools-instrument": "^1.8.2",
     "rimraf": "^2.5.3"
   },
   "nyc": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,12 @@ export const BEGIN = '@@optimist/BEGIN';
 export const COMMIT = '@@optimist/COMMIT';
 export const REVERT = '@@optimist/REVERT';
 
-export const ensureState = state => {
-  if (state && Array.isArray(state.history)) {
-    return state.current;
-  }
-  return state;
-};
+const isOptimistState = state => state && Object.keys(state).length === 3
+  && state.hasOwnProperty('beforeState')
+  && state.hasOwnProperty('history')
+  && state.hasOwnProperty('current');
+
+export const ensureState = state => isOptimistState(state) ? state.current : state;
 
 const createState = state => ({
   beforeState: undefined,
@@ -98,7 +98,7 @@ export const optimistic = (reducer, rawConfig = {}) => {
   }, rawConfig);
 
   return (state, action) => {
-    if (state === undefined || action.type === '@@redux/INIT') {
+    if (state === undefined || !isOptimistState(state)) {
       state = createState(reducer(ensureState(state), {}));
     }
     const historySize = state.history.length;


### PR DESCRIPTION
Prevously we would only wrap the state in the redux-optimistic-ui wrapper if the passed
in state was undefined, or this was the `@@redux/INIT` action. However when initial state is
passed to `createStore` other middleware, notably the Redux devtools instrumentation, will
trigger an `@@INIT` action with the unwrapped state. This wouldn't match our check, and so
would later throw an error as it wasn't wrapped state.

The check for whether wrapped state has been passed to our reducer has been rewritten, instead
we now look for a special marker property. This prevents any chance of false positives if you
happen to have `current` and `history` in your reducer.